### PR TITLE
Handle null entries when sorting by creation date

### DIFF
--- a/src/components/Accueil.jsx
+++ b/src/components/Accueil.jsx
@@ -35,10 +35,12 @@ const useFetch = url => {
     let json = await response.json();
     // Ensure we can sort even if the API returns an object instead of an array
     json = Array.isArray(json) ? json : Object.values(json);
-    json.sort((a, b) => (b.created_at || '').localeCompare(a.created_at || ''));
+    // Remove any null/undefined entries and safely sort by creation date
+    json = json.filter(Boolean);
+    json.sort((a, b) => (b?.created_at || '').localeCompare(a?.created_at || ''));
 /*    console.log("yo "+response.headers);*/
     setData(json);
-   setLoading(false);  
+   setLoading(false);
   }
 
   useEffect(() => {

--- a/src/components/arenas.jsx
+++ b/src/components/arenas.jsx
@@ -19,6 +19,8 @@ const useFetch = url => {
     const response = await fetch(url);
     let json = await response.json();
     json = Array.isArray(json) ? json : Object.values(json);
+    // Remove any null or undefined entries to avoid runtime errors
+    json = json.filter(Boolean);
     setData(json);
     setLoading(false);
   }
@@ -55,19 +57,23 @@ function Arenas() {
                       </TableRow>
       
                     </TableHead>
-                    <TableBody>
-            
-                      {data.map(arenas => 
-                      (
-      
-                        <TableRow key={arenas.id} >
-                          <TableCell align="center"><a href={arenas.lienGoogle}><LocationIcon></LocationIcon></a></TableCell>
-                          <TableCell align="center">{arenas.Nom}</TableCell>
-                          <TableCell align="center">{arenas.Adresse}<br/>{arenas.telephone}</TableCell>
-                        </TableRow>
-                    
-                          ))}
-                    </TableBody>
+                      <TableBody>
+                        {data.filter(Boolean).map((arenas) => (
+                          <TableRow key={arenas.id}>
+                            <TableCell align="center">
+                              <a href={arenas.lienGoogle}>
+                                <LocationIcon></LocationIcon>
+                              </a>
+                            </TableCell>
+                            <TableCell align="center">{arenas.Nom}</TableCell>
+                            <TableCell align="center">
+                              {arenas.Adresse}
+                              <br />
+                              {arenas.telephone}
+                            </TableCell>
+                          </TableRow>
+                        ))}
+                      </TableBody>
                   </Table>
                 </Paper>
                 }

--- a/src/components/matchs.jsx
+++ b/src/components/matchs.jsx
@@ -20,6 +20,8 @@ const useFetch = () => {
     const response = await fetch("/api/equipes");
     let json = await response.json();
     json = Array.isArray(json) ? json : Object.values(json);
+    // Remove any null/undefined entries before setting state
+    json = json.filter(Boolean);
     setData(json);
     setLoading(false);
   }
@@ -80,19 +82,19 @@ function Matchs() {
 
             </TableHead>
             <TableBody>
-           
-             {  data.map(equipe => 
-              (
-                
-                equipe.PageMatchHM==null? null :
-                <TableRow key={equipe.id} >
-                  <TableCell component="th" scope="row">
-                    {equipe.id}
-                  </TableCell>
-                  <TableCell   onChange={()=>{fetch(equipe.PageMatchHM)}} align="right"><a href={equipe.PageMatchHM} target="_blank">{equipe.Nom}</a></TableCell>
-                </TableRow>
-                
-                  ))}
+
+             {  data
+                .filter(Boolean)
+                .map(equipe => (
+                  equipe?.PageMatchHM == null ? null : (
+                    <TableRow key={equipe.id} >
+                      <TableCell component="th" scope="row">
+                        {equipe.id}
+                      </TableCell>
+                      <TableCell onChange={()=>{fetch(equipe.PageMatchHM)}} align="right"><a href={equipe.PageMatchHM} target="_blank">{equipe.Nom}</a></TableCell>
+                    </TableRow>
+                  )
+                ))}
             </TableBody>
           </Table>
           </Paper>

--- a/src/components/nouvelles.jsx
+++ b/src/components/nouvelles.jsx
@@ -28,7 +28,9 @@ const useFetch = url => {
     let json = await response.json();
     // Normalize JSON to an array before sorting
     json = Array.isArray(json) ? json : Object.values(json);
-    json.sort((a, b) => (b.created_at || '').localeCompare(a.created_at || ''));
+    // Filter out null/undefined entries then safely sort by creation date
+    json = json.filter(Boolean);
+    json.sort((a, b) => (b?.created_at || '').localeCompare(a?.created_at || ''));
     setData(json);
     setLoading(false)  }
 

--- a/src/components/pratiques.jsx
+++ b/src/components/pratiques.jsx
@@ -39,6 +39,8 @@ const useFetch = () => {
       const responseEquipes = await fetch("/api/equipes");
       let equipes = await responseEquipes.json();
       equipes = Array.isArray(equipes) ? equipes : Object.values(equipes);
+      // Remove null or undefined team entries
+      equipes = equipes.filter(Boolean);
 
       setData(pratiques);
       setEquipes(equipes);
@@ -149,22 +151,23 @@ function Pratiques() {
                 </TableRow>
               </TableHead>
               <TableBody>
-                {data
-                  .filter(
-                    (pratiques) =>
-                      Object.keys(pratiques.equipes || {})
-                        .filter(
-                          (key) =>
-                            pratiques.equipes[key].id == selEquipe ||
-                            selEquipe == 0
-                        )
-                        .filter(
-                          (key) =>
-                            new Date(pratiques.Jour) >= aujourdhui ||
-                            inclusAncien
-                        ).length > 0
-                  )
-                  .map((pratiques) => (
+                  {data
+                    .filter(
+                      (pratiques) =>
+                        Object.keys(pratiques.equipes || {})
+                          .filter((key) => pratiques.equipes[key])
+                          .filter(
+                            (key) =>
+                              pratiques.equipes[key].id == selEquipe ||
+                              selEquipe == 0
+                          )
+                          .filter(
+                            () =>
+                              new Date(pratiques.Jour) >= aujourdhui ||
+                              inclusAncien
+                          ).length > 0
+                    )
+                    .map((pratiques) => (
                     <TableRow key={pratiques.id}>
                       <TableCell align="right">
                         {joursSemaine[new Date(pratiques.Jour).getDay()]}
@@ -176,12 +179,14 @@ function Pratiques() {
                         )}
                       </TableCell>
                       <TableCell align="right">
-                        {Object.keys(pratiques.equipes || {}).map((cleEq) => (
-                          <span key={pratiques.equipes[cleEq].id}>
-                            {pratiques.equipes[cleEq].Nom}
-                            <br />
-                          </span>
-                        ))}
+                        {Object.keys(pratiques.equipes || {})
+                          .filter((cleEq) => pratiques.equipes[cleEq])
+                          .map((cleEq) => (
+                            <span key={pratiques.equipes[cleEq].id}>
+                              {pratiques.equipes[cleEq].Nom}
+                              <br />
+                            </span>
+                          ))}
                       </TableCell>
                       <TableCell align="right">
                         {pratiques.Debut.split(':')[0] +

--- a/src/components/pratiques.jsx
+++ b/src/components/pratiques.jsx
@@ -23,12 +23,14 @@ const useFetch = () => {
       let pratiques = await responsePratiques.json();
       // Normalize JSON to an array before sorting
       pratiques = Array.isArray(pratiques) ? pratiques : Object.values(pratiques);
+      // Remove any null/undefined entries before sorting
+      pratiques = pratiques.filter(Boolean);
       pratiques.sort((a, b) => {
-        const jourA = a.Jour || '';
-        const jourB = b.Jour || '';
+        const jourA = a?.Jour || '';
+        const jourB = b?.Jour || '';
         if (jourA.localeCompare(jourB) === 0) {
-          const debutA = a.Debut || '';
-          const debutB = b.Debut || '';
+          const debutA = a?.Debut || '';
+          const debutB = b?.Debut || '';
           return debutA.localeCompare(debutB);
         }
         return jourA.localeCompare(jourB);


### PR DESCRIPTION
## Summary
- avoid runtime errors by filtering out null entries and using safe sorting in useFetch

## Testing
- `npm test -- --watchAll=false` *(fails: Invariant failed: You should not use <withRouter(NavTabs) /> outside a <Router>)*

------
https://chatgpt.com/codex/tasks/task_e_68922980b1648326ab2441d0439912c0